### PR TITLE
Dereference link for sshuttle launcher script if it's a symlink

### DIFF
--- a/sshuttle
+++ b/sshuttle
@@ -1,5 +1,7 @@
 #!/bin/sh
 DIR=$(dirname "$0")
+DIR="$(dirname ${DIR}/$(readlink -n $0))"
+DIR="$(cd $DIR;pwd)"
 if python2 -V 2>/dev/null; then
 	exec python2 "$DIR/main.py" python2 "$@"
 else


### PR DESCRIPTION
I have the launcher script symlinked into ~/bin, but it doesn't properly locate the python script as $(dirname $0) is ~/bin in that case.

This is a really ugly way to dereference that symlink, but I couldn't find any better way to do it with BSD coreutils. Seems like `readlink -f` for GNU coreutils would do the trick, but that doesn't work on OS X.
This might not be the best way to do it, but it works...
