### PR TITLE
Add a command line option to exclude subnets listed in a file

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ dns        capture local DNS requests and forward to the remote DNS server
 python=    path to python interpreter on the remote server
 r,remote=  ssh hostname (and optional username) of remote sshuttle server
 x,exclude= exclude this subnet (can be used more than once)
+X,exclude-from=  exclude the subnets in a file (one subnet per line)
 v,verbose  increase debug message verbosity
 e,ssh-cmd= the command to use to connect to the remote [ssh]
 seed-hosts= with -H, use these hostnames for initial scan (comma-separated)
@@ -99,6 +100,10 @@ try:
         for k,v in flags:
             if k in ('-x','--exclude'):
                 excludes.append(v)
+            if k in ('-X', '--exclude-file'):
+                f = open(v)
+                excludes.extend(f.readlines())
+                f.close()
         remotename = opt.remote
         if remotename == '' or remotename == '-':
             remotename = None

--- a/sshuttle.md
+++ b/sshuttle.md
@@ -90,6 +90,11 @@ entire subnet to the VPN.
     `0/0 -x 1.2.3.0/24` to forward everything except the
     local subnet over the VPN, for example.
 
+-X, --exclude-from=*file*
+:   exclude the subnets specified in a file, one subnet per
+    line. Useful when you have lots of subnets to exclude
+    (e.g. all IPs within a particular country).
+
 -v, --verbose
 :   print more information about the session.  This option
     can be used more than once for increased verbosity.  By


### PR DESCRIPTION
It is useful when user wants to specify lots of subnets to exclude, in my case it's all IP ranges within China. Please review and merge this. Thanks.

BTW, I'm also thinking of implement a configuration file format to make it behave more like OpenVPN-like daemons. Do you think it's a good idea? What kind of format do you prefer? I think for now just read the conf file exactly the same way command line is good enough, i.e. one key[=value] option per line.
