### PR TITLE
Fix runpython.do for systems with unxpected configurations

### DIFF
--- a/ui-macos/bits/runpython.do
+++ b/ui-macos/bits/runpython.do
@@ -2,12 +2,14 @@ exec >&2
 redo-ifchange runpython.c
 ARCHES=""
 printf "Platforms: "
-for d in /usr/libexec/gcc/darwin/*; do
-    PLAT=$(basename "$d")
-    [ "$PLAT" != "ppc64" ] || continue  # fails for some reason on my Mac
-    ARCHES="$ARCHES -arch $PLAT"
-    printf "$PLAT "
-done
+if [[ -d /usr/llvm-gcc-4.2/libexec/gcc/darwin ]]; then
+    for d in /usr/llvm-gcc-4.2/libexec/gcc/darwin/*; do
+        PLAT=$(basename "$d")
+        [ "$PLAT" != "ppc64" ] || continue  # fails for some reason on my Mac
+        ARCHES="$ARCHES -arch $PLAT"
+        printf "$PLAT "
+    done
+fi
 printf "\n"
 gcc $ARCHES \
 	-Wall -o $3 runpython.c \


### PR DESCRIPTION
If the expected arch directory doesn't exist, give up and don't specify arch at
all. Currently it expands to '*' which fails.
