### PR TITLE
Backporting server.py to python2.2

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,3 +1,4 @@
+from __future__ import generators # add yield for python2.2
 import re, struct, socket, select, traceback, time
 if not globals().get('skip_imports'):
     import ssnet, helpers, hostwatch
@@ -43,7 +44,7 @@ def _maskbits(netmask):
     
     
 def _shl(n, bits):
-    return n * int(2**bits)
+    return n * long(2**bits)
 
 
 def _list_routes():


### PR DESCRIPTION
I only did server.py because it was all I needed to do to sshuttle to servers with crazy out of date python version. This is mostly for my own needs, but the patch is small (two lines) so I posted it in case you want to merge it in to the line main code. 
