### PR TITLE
Use the Python "framework"

### DIFF
--- a/ui-macos/bits/runpython.c
+++ b/ui-macos/bits/runpython.c
@@ -6,7 +6,7 @@
  * NSApplicationMain() looks for Info.plist using the path in argv[0], which
  * goes wrong if your interpreter is /usr/bin/python.
  */
-#include <Python.h>
+#include <Python/Python.h>
 #include <string.h>
 #include <unistd.h>
 

--- a/ui-macos/bits/runpython.do
+++ b/ui-macos/bits/runpython.do
@@ -13,5 +13,4 @@ fi
 printf "\n"
 gcc $ARCHES \
 	-Wall -o $3 runpython.c \
-	-I/usr/include/python2.5 \
-	-lpython2.5
+	-framework Python


### PR DESCRIPTION
This fixes the build on Mac OS X 10.11.3 "El Capitan", and probably works on older versions as well. Based on this answer on stack overflow: http://stackoverflow.com/a/16454614/196315 