### PR TITLE
Fix splitting of multi-word arguments

### DIFF
--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -4,6 +4,7 @@ import re
 import socket
 import struct
 import subprocess as ssubprocess
+import shlex
 from fcntl import ioctl
 from ctypes import c_char, c_uint8, c_uint16, c_uint32, Union, Structure, \
     sizeof, addressof, memmove
@@ -323,7 +324,7 @@ else:
 
 
 def pfctl(args, stdin=None):
-    argv = ['pfctl'] + list(args.split(" "))
+    argv = ['pfctl'] + shlex.split(args)
     debug1('>> %s\n' % ' '.join(argv))
 
     p = ssubprocess.Popen(argv, stdin=ssubprocess.PIPE,

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -5,6 +5,7 @@ import socket
 import zlib
 import imp
 import subprocess as ssubprocess
+import shlex
 import sshuttle.helpers as helpers
 from sshuttle.helpers import debug2
 
@@ -102,7 +103,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         argv = [sys.argv[1], '-c', pyscript]
     else:
         if ssh_cmd:
-            sshl = ssh_cmd.split(' ')
+            sshl = shlex.split(ssh_cmd)
         else:
             sshl = ['ssh']
         if python:


### PR DESCRIPTION
I tried setting a multi-word SSH option through `ssh -o` and `sshuttle -e`. This didn't work because regardless of the quoting, sshuttle always split the option into multiple arguments and made the quotes become a literal part of the args.

The problem turned out to be caused by shuttle always splitting the arguments at spaces, which makes it practically impossible to have multi-word arguments.

This patch solves the issue by using Python's shlex module, which splits arguments like a shell and e.g. respects quotes. I found one more similar line in the sshuttle code and fixed that one as well.
