### PR TITLE
Use shlex.split so we can escape spaces if necessary (eg ProxyCommand)

### DIFF
--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import re
+import shlex
 import socket
 import zlib
 import imp
@@ -102,7 +103,7 @@ def connect(ssh_cmd, rhostport, python, stderr, options):
         argv = [sys.argv[1], '-c', pyscript]
     else:
         if ssh_cmd:
-            sshl = ssh_cmd.split(' ')
+            sshl = shlex.split(ssh_cmd)
         else:
             sshl = ['ssh']
         if python:


### PR DESCRIPTION
As it says on the tin, I use this so I can use spaces with my ssh command (in ProxyCommand)
