### PR TITLE
Disambiguate licencing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,14 @@ setup(
     author_email='brian@linuxpenguins.xyz',
     description='Full-featured" VPN over an SSH tunnel',
     packages=find_packages(),
-    license="GPL2+",
+    license="LGPL2+",
     long_description=open('README.rst').read(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Intended Audience :: End Users/Desktop",
         "License :: OSI Approved :: "
-            "GNU General Public License v2 or later (GPLv2+)",
+            "GNU Lesser General Public License v2 or later (LGPLv2+)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",

--- a/sshuttle/__main__.py
+++ b/sshuttle/__main__.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 """Coverage.py's main entry point."""
 import sys
 from sshuttle.cmdline import main

--- a/sshuttle/assembler.py
+++ b/sshuttle/assembler.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import sys
 import zlib
 import imp

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import socket
 import errno
 import re

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import sys
 import re
 import socket

--- a/sshuttle/firewall.py
+++ b/sshuttle/firewall.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import errno
 import socket
 import signal

--- a/sshuttle/helpers.py
+++ b/sshuttle/helpers.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import sys
 import socket
 import errno

--- a/sshuttle/hostwatch.py
+++ b/sshuttle/hostwatch.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import time
 import socket
 import re

--- a/sshuttle/linux.py
+++ b/sshuttle/linux.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import socket
 import subprocess as ssubprocess
 from sshuttle.helpers import log, debug1, Fatal, family_to_string

--- a/sshuttle/methods/__init__.py
+++ b/sshuttle/methods/__init__.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import os
 import importlib
 import socket

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import socket
 from sshuttle.helpers import family_to_string
 from sshuttle.linux import ipt, ipt_ttl, ipt_chain_exists, nonfatal

--- a/sshuttle/methods/pf.py
+++ b/sshuttle/methods/pf.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import os
 import sys
 import re

--- a/sshuttle/methods/tproxy.py
+++ b/sshuttle/methods/tproxy.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import struct
 from sshuttle.helpers import family_to_string
 from sshuttle.linux import ipt, ipt_ttl, ipt_chain_exists

--- a/sshuttle/options.py
+++ b/sshuttle/options.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 """Command-line options parser.
 With the help of an options spec string, easily parse command-line options.
 """

--- a/sshuttle/server.py
+++ b/sshuttle/server.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import re
 import struct
 import socket

--- a/sshuttle/ssh.py
+++ b/sshuttle/ssh.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import sys
 import os
 import re

--- a/sshuttle/ssnet.py
+++ b/sshuttle/ssnet.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import struct
 import socket
 import errno

--- a/sshuttle/ssyslog.py
+++ b/sshuttle/ssyslog.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import sys
 import os
 import subprocess as ssubprocess

--- a/sshuttle/stresstest.py
+++ b/sshuttle/stresstest.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python
+
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import socket
 import select
 import struct

--- a/sshuttle/tests/test_firewall.py
+++ b/sshuttle/tests/test_firewall.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 from mock import Mock, patch, call
 import io
 

--- a/sshuttle/tests/test_helpers.py
+++ b/sshuttle/tests/test_helpers.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 from mock import patch, call
 import sys
 import io

--- a/sshuttle/tests/test_methods_nat.py
+++ b/sshuttle/tests/test_methods_nat.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import pytest
 from mock import Mock, patch, call
 import socket

--- a/sshuttle/tests/test_methods_pf.py
+++ b/sshuttle/tests/test_methods_pf.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 import pytest
 from mock import Mock, patch, call, ANY
 import socket

--- a/sshuttle/tests/test_methods_tproxy.py
+++ b/sshuttle/tests/test_methods_tproxy.py
@@ -1,3 +1,20 @@
+# This file is part of sshuttle, a transparent SSH proxy/VPN.
+# Copyright (C) 2016 the sshuttle authors
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the Free
+# Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
 from mock import Mock, patch, call
 
 from sshuttle.methods import get_method


### PR DESCRIPTION
Consider this a bug report with a patch attached :-)

`sshuttle`'s current licence terms are a bit unclear. The LICENSE file is a copy of the LGPL, but none of the source files contain the suggested — if not mandatory — notice header.

I've added some, and corrected `setup.py` to no longer incorrectly declare the project GPL in places like [PyPI](pypi.python.org).

I wasn't sure whom to credit. I'll gladly update the PR with any suggestions.