### PR TITLE
Excluded acl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ sshuttle/version.py
 /.do_built
 /.do_built.dir
 /.redo
+.eggs/
+.idea/
+build/
+dist/
+sshuttle.egg-info/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+dnslib
+netifaces
 setuptools_scm
 py2-ipaddress
 watchdog

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ netifaces
 setuptools_scm
 py2-ipaddress
 watchdog
+filelock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-dnslib
 netifaces
 setuptools_scm
 py2-ipaddress

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 setuptools_scm
+py2-ipaddress
+watchdog

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -15,8 +15,6 @@ from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers
 from sshuttle.methods import get_method, Features
-from dnslib import *
-import netifaces
 
 import ipaddress
 from watchdog.observers import Observer

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -471,7 +471,7 @@ class AclHandler(FileSystemEventHandler):
         global _acl_list
         _acl_list = {}
         if (not self.acl_file_exists):
-            _acl_file = None
+            _acl_list = None
             return
         with open(self.acl_path, 'r') as acl:
             line_format = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}\:\d{1,5}(\-\d{1,5})?$")

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -398,9 +398,9 @@ def connection_is_allowed(dstip, dstport):
     # check for subnet rule
     for cidr_entry in _acl_list:
         if (cidr_entry != "0.0.0.0/0" and int(cidr_entry.split("/")[1]) != 32):
-            network = ipaddress.ip_network(cidr_entry)
-            addr = ipaddress.ip_address(dstip)
-            if (addr in network.hosts()):
+            network = ipaddress.ip_network(unicode(cidr_entry))
+            addr = ipaddress.ip_network(unicode(dstip + "/32"))
+            if (addr.subnet_of(network)):
                 if (acl_entry_match(cidr_entry, dstport)):
                     return True
 

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -458,6 +458,7 @@ class AclHandler(FileSystemEventHandler):
 
     def __init__(self, path):
         self.acl_path = path
+        self.file_exists = False
         if (os.path.exists(path)):
             self.file_exists = True
 

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -335,8 +335,10 @@ def onaccept_tcp(listener, method, mux, handlers):
 
     dstip = method.get_tcp_dstip(sock)
 
-    if (acl_file_exists()):
+    if _acl_list is not None:
         if not connection_is_allowed(dstip[0], str(dstip[1])):
+            debug1('Deny TCP: %s:%r -> %s:%r.\n' % (srcip[0], srcip[1],
+                                                    dstip[0], dstip[1]))
             sock.close()
             return
 
@@ -357,17 +359,14 @@ def onaccept_tcp(listener, method, mux, handlers):
     handlers.append(Proxy(SockWrapper(sock, sock), outwrap))
     expire_connections(time.time(), mux)
 
-
-def acl_file_exists(self):
-    return self.acl_file_exists
-
 def port_in_range(port_range, port):
 
     parsed_range = port_range.split("-")
-    port_start = parsed_range[0]
-    port_end = parsed_range[1]
+    port_start = int(parsed_range[0])
+    port_end = int(parsed_range[1])
+    dest_port = int(port)
 
-    if (port >= port_start and port <= port_end):
+    if (dest_port >= port_start and dest_port <= port_end):
         return True
 
     return False
@@ -472,6 +471,7 @@ class AclHandler(FileSystemEventHandler):
         global _acl_list
         _acl_list = {}
         if (not self.acl_file_exists):
+            _acl_file = None
             return
         with open(self.acl_path, 'r') as acl:
             line_format = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\/\d{1,2}\:\d{1,5}(\-\d{1,5})?$")

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -528,7 +528,10 @@ class AclHandler(FileSystemEventHandler):
             _allowed_sources = None
             return
         with open(self.acl_path, 'r') as acl:
-            _allowed_sources = json.loads(acl.read())
+            try:
+                _allowed_sources = json.loads(acl.read())
+            except BaseException as e:
+                log("An exception has occurred while loading the sources file: {}\n\n".format(e))
 
         log("Network Connection Sources ACL \n\n%s" % _allowed_sources)
 

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -17,7 +17,7 @@ from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
 from sshuttle.methods import get_method, Features
 
 import ipaddress
-from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver as Observer
 from watchdog.events import FileSystemEventHandler
 
 _extra_fd = os.open('/dev/null', os.O_RDONLY)
@@ -515,11 +515,6 @@ class AclHandler(FileSystemEventHandler):
             self.reload_acl_list()
 
     def on_created(self, event):
-
-        if (self.acl_file_exists):
-            # modifying a file triggers a create so no need
-            # to call the handler if the file already exists
-            return
 
         if (event.src_path == self.acl_path):
             self.acl_file_exists = True

--- a/sshuttle/client.py
+++ b/sshuttle/client.py
@@ -15,10 +15,52 @@ from sshuttle.ssnet import SockWrapper, Handler, Proxy, Mux, MuxWrapper
 from sshuttle.helpers import log, debug1, debug2, debug3, Fatal, islocal, \
     resolvconf_nameservers
 from sshuttle.methods import get_method, Features
+from dnslib import *
+import netifaces
 
 import ipaddress
 from watchdog.observers import Observer
 from watchdog.events import FileSystemEventHandler
+
+class DomainName(str):
+    def __getattr__(self, item):
+        return DomainName(item + '.' + self)
+D = DomainName('microservices.vela.pythian.com.')
+
+# determine the private IP of the instance
+IP = '127.0.0.1'
+privateNetwork1 = ipaddress.ip_network(unicode('10.0.0.0/8'))
+privateNetwork2 = ipaddress.ip_network(unicode('172.16.0.0/12'))
+privateNetwork3 = ipaddress.ip_network(unicode('192.168.0.0/16'))
+
+for interface in netifaces.interfaces():
+    interfaceAddress = netifaces.ifaddresses(interface)
+    if netifaces.AF_INET in interfaceAddress and len(interfaceAddress[netifaces.AF_INET]) > 0 and 'addr' in interfaceAddress[netifaces.AF_INET][0]:
+        IP = netifaces.ifaddresses(interface)[netifaces.AF_INET][0]['addr']
+        singleIpNetwork = ipaddress.ip_network(unicode(IP + "/32"))
+        if singleIpNetwork.subnet_of(privateNetwork1) or singleIpNetwork.subnet_of(privateNetwork2) or singleIpNetwork.subnet_of(privateNetwork3):
+            break;
+
+TTL = 60 * 5
+soa_record = SOA(
+    mname=D.ns1,  # primary name server
+    rname=D.admin,  # email of the domain administrator
+    times=(
+        201307231,  # serial number
+        60 * 60 * 1,  # refresh
+        60 * 60 * 3,  # retry
+        60 * 60 * 24,  # expire
+        60 * 60 * 1,  # minimum
+    )
+)
+ns_records = [NS(D.ns1), NS(D.ns2)]
+records = {
+    D: [A(IP), AAAA((0,) * 16), MX(D.mail), soa_record] + ns_records,
+    D.ns1: [A(IP)],  # MX and NS records must never point to a CNAME alias (RFC 2181 section 10.3)
+    D.ns2: [A(IP)],
+    D.mail: [A(IP)],
+    D.admin: [CNAME(D)],
+}
 
 _extra_fd = os.open('/dev/null', os.O_RDONLY)
 
@@ -434,7 +476,7 @@ def onaccept_udp(listener, method, mux, handlers):
 
 
 def dns_done(chan, data, method, sock, srcip, dstip, mux):
-    debug3('dns_done: channel=%d src=%r dst=%r\n' % (chan, srcip, dstip))
+    debug3('dns_done: channel=%d src=%r dst=%r\n%r\n' % (chan, srcip, dstip, data))
     del mux.channels[chan]
     del dnsreqs[chan]
     method.send_udp(sock, srcip, dstip, data)
@@ -446,12 +488,39 @@ def ondns(listener, method, mux, handlers):
     if t is None:
         return
     srcip, dstip, data = t
-    debug1('DNS request from %r to %r: %d bytes\n' % (srcip, dstip, len(data)))
+
+    request = DNSRecord.parse(data)
+    reply = DNSRecord(DNSHeader(id=request.header.id, qr=1, aa=1, ra=1), q=request.q)
+
+    qname = request.q.qname
+    qn = str(qname)
+    qtype = request.q.qtype
+    qt = QTYPE[qtype]
+
+    debug1('DNS request from %r to %r: %d bytes\n%r\n' % (srcip, dstip, len(data), request))
     chan = mux.next_channel()
     dnsreqs[chan] = now + 30
-    mux.send(chan, ssnet.CMD_DNS_REQ, data)
     mux.channels[chan] = lambda cmd, data: dns_done(
         chan, data, method, listener, srcip=dstip, dstip=srcip, mux=mux)
+
+    if qn == D or qn.endswith('.' + D):
+
+        for name, rrs in records.items():
+            if name == qn:
+                for rdata in rrs:
+                    rqt = rdata.__class__.__name__
+                    if qt in ['*', rqt]:
+                        reply.add_answer(RR(rname=qname, rtype=getattr(QTYPE, rqt), rclass=1, ttl=TTL, rdata=rdata))
+
+        for rdata in ns_records:
+            reply.add_ar(RR(rname=D, rtype=QTYPE.NS, rclass=1, ttl=TTL, rdata=rdata))
+
+        reply.add_auth(RR(rname=D, rtype=QTYPE.SOA, rclass=1, ttl=TTL, rdata=soa_record))
+
+        dns_done(chan, reply.pack(), method, listener, srcip=dstip, dstip=srcip, mux=mux)
+    else:
+        mux.send(chan, ssnet.CMD_DNS_REQ, data)
+
     expire_connections(now, mux)
 
 class AclHandler(FileSystemEventHandler):

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -136,6 +136,7 @@ D,daemon   run in the background as a daemon
 s,subnets= file where the subnets are stored, instead of on the command line
 a,acl=     file where the allowed ACL rules is stored
 aclsources=      file where the ACL Sources rules are stored
+aclexcludedsources= file where the excluded hosts acl rules are stored
 disallowedacl=   file where the disallowed acl rules are stored
 syslog     send log messages to syslog (default if you use --daemon)
 pidfile=   pidfile name (only if using --daemon) [./sshuttle.pid]
@@ -230,6 +231,7 @@ def main():
                                       opt.acl,
                                       opt.disallowedacl,
                                       opt.aclsources,
+                                      opt.aclexcludedsources,
                                       opt.daemon, opt.pidfile)
 
             if return_code == 0:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -134,7 +134,9 @@ wrap=      restart counting channel numbers after this number (for testing)
 disable-ipv6 disables ipv6 support
 D,daemon   run in the background as a daemon
 s,subnets= file where the subnets are stored, instead of on the command line
-a,acl=     file where the ACL is stored, instead of on the command line
+a,acl=     file where the allowed ACL rules is stored
+aclsources=      file where the ACL Sources rules are stored
+disallowedacl=   file where the disallowed acl rules are stored
 syslog     send log messages to syslog (default if you use --daemon)
 pidfile=   pidfile name (only if using --daemon) [./sshuttle.pid]
 server     (internal use only)
@@ -226,6 +228,8 @@ def main():
                                       parse_subnets(includes),
                                       parse_subnets(excludes),
                                       opt.acl,
+                                      opt.disallowedacl,
+                                      opt.aclsources,
                                       opt.daemon, opt.pidfile)
 
             if return_code == 0:

--- a/sshuttle/cmdline.py
+++ b/sshuttle/cmdline.py
@@ -134,6 +134,7 @@ wrap=      restart counting channel numbers after this number (for testing)
 disable-ipv6 disables ipv6 support
 D,daemon   run in the background as a daemon
 s,subnets= file where the subnets are stored, instead of on the command line
+a,acl=     file where the ACL is stored, instead of on the command line
 syslog     send log messages to syslog (default if you use --daemon)
 pidfile=   pidfile name (only if using --daemon) [./sshuttle.pid]
 server     (internal use only)
@@ -211,6 +212,7 @@ def main():
             if opt.syslog:
                 ssyslog.start_syslog()
                 ssyslog.stderr_to_syslog()
+
             return_code = client.main(ipport_v6, ipport_v4,
                                       opt.ssh_cmd,
                                       remotename,
@@ -223,6 +225,7 @@ def main():
                                       opt.auto_nets,
                                       parse_subnets(includes),
                                       parse_subnets(excludes),
+                                      opt.acl,
                                       opt.daemon, opt.pidfile)
 
             if return_code == 0:

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -34,21 +34,24 @@ class Method(BaseMethod):
         # basic cleanup/setup of chains
         self.restore_firewall(port, family, udp)
 
-        # add a rule to route requests to 1.0.0.0 to localhost
-        _ipt('-t', 'nat', '-A', 'PREROUTING', '-d', '1.0.0.0',  '-j', 'DNAT',
-             '--to-destination', '127.0.0.1')
-
         _ipt('-N', chain)
         _ipt('-F', chain)
         _ipt('-I', 'OUTPUT', '1', '-j', chain)
         _ipt('-I', 'PREROUTING', '1', '-j', chain)
 
-        # add a rule as the first entry to not route packets that are
-        # generated locally though sshuttle
+        # get the address of eth0
         ni.ifaddresses('eth0')
         ip = ni.ifaddresses('eth0')[2][0]['addr']
+
+        # add a rule not route packets that are
+        # generated locally though sshuttle
         _ipt('-A', chain, '-j', 'RETURN',
              '--src', '%s/32' % ip)
+
+        # add a rule to not route packets that are
+        # destined to the local address though sshuttle
+        _ipt('-A', chain, '-j', 'RETURN',
+             '--dest', '%s/32' % ip)
 
         # create new subnet entries.  Note that we're sorting in a very
         # particular order: we need to go from most-specific (largest
@@ -90,10 +93,6 @@ class Method(BaseMethod):
 
         def _ipt_ttl(*args):
             return ipt_ttl(family, table, *args)
-
-        # remove rule to route requests to 1.0.0.0 to localhost
-        nonfatal(_ipt, '-D', 'PREROUTING', '-d', '1.0.0.0',  '-j', 'DNAT',
-                 '--to-destination', '127.0.0.1')
 
         chain = 'sshuttle-%s' % port
 

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -53,6 +53,11 @@ class Method(BaseMethod):
         _ipt('-A', chain, '-j', 'RETURN',
              '--dest', '%s/32' % ip)
 
+        # add a rule not route packets that are
+        # originate from the container network
+        _ipt('-A', chain, '-j', 'RETURN',
+             '--src', '172.17.0.0/16')
+
         # create new subnet entries.  Note that we're sorting in a very
         # particular order: we need to go from most-specific (largest
         # swidth) to least-specific, and at any given level of specificity,

--- a/sshuttle/methods/nat.py
+++ b/sshuttle/methods/nat.py
@@ -58,6 +58,11 @@ class Method(BaseMethod):
         _ipt('-A', chain, '-j', 'RETURN',
              '--src', '172.17.0.0/16')
 
+        # add a rule not route packets that are
+        # destined to the container network
+        _ipt('-A', chain, '-j', 'RETURN',
+             '--dest', '172.17.0.0/16')
+
         # create new subnet entries.  Note that we're sorting in a very
         # particular order: we need to go from most-specific (largest
         # swidth) to least-specific, and at any given level of specificity,


### PR DESCRIPTION
Allows non-expired leases in the excluded sources file to completely bypass the sshuttle_acl and the acl_sources controls. 

Adds a command line option and implements the file locking around the excluded sources file that was recently introduced.